### PR TITLE
Add PHP 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "dino/dompdf-module": "0.*"
     },
     "require": {
-        "php": "~7.4.1 || ~8.0.0 || ~8.1.0",
+        "php": "~7.4.1 || ~8.0.0 || ~8.1.0 || ~8.2.0",
         "laminas/laminas-servicemanager": "^3.4.1",
         "laminas/laminas-modulemanager": "^2.10.1",
         "laminas/laminas-eventmanager": "^3.3.0",


### PR DESCRIPTION
Allows PHP 8.2

## Change Profile

| Question      | Answer
| ------------- | ---
| New feature   | no
| Bug fix       | no
| BC breaks     | no


## Description
Add PHP 8.2 to the list

## Reason
PHP 8.2 is out for 9 months now 
